### PR TITLE
Add version request command.

### DIFF
--- a/inc/main.h
+++ b/inc/main.h
@@ -25,6 +25,7 @@ extern "C" {
 
 #include "stm32f0xx_hal.h"
 #include "shift_reg.h"
+#include "version.h"
 
 void Error_Handler(void);
 

--- a/inc/main.h
+++ b/inc/main.h
@@ -157,7 +157,7 @@ void Error_Handler(void);
 #define DEBOUNCE_TICKS 40
 
 /* DDR Init timeout in ms */
-#define DDR_TIMEOUT_TICKS 600
+#define SERIAL_TIMEOUT_TICKS 600
 
 #ifdef __cplusplus
 }

--- a/inc/version.h
+++ b/inc/version.h
@@ -1,0 +1,33 @@
+/**
+  ******************************************************************************
+  * @file           : version.h
+  * @brief          : This file contains the defines of the firmware version.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2023 BlueDot Arcade.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+#ifndef __VERSION_H
+#define __VERSION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VERSION_MAJOR 0
+#define VERSION_MINOR 0
+#define VERSION_PATCH 3 
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __VERSION_H */

--- a/src/main.c
+++ b/src/main.c
@@ -369,7 +369,7 @@ void Serial_Idle_Clock_Handler(void)
 
   uint8_t data = HAL_GPIO_ReadPin(COMM_FL5_GPIO_Port, COMM_FL5_Pin);
   
-  /* Assemble 12-bits command */
+  /* Assemble 13-bits command */
   Serial_Cmd = (Serial_Cmd >> 1) | (data << 12); 
 
   switch(Serial_Cmd)

--- a/src/main.c
+++ b/src/main.c
@@ -19,10 +19,6 @@
 #include "gpio.h"
 #include "tim.h"
 
-#define FW_VERSION_MAJOR 1
-#define FW_VERSION_MINOR 2
-#define FW_VERSION_PATCH 3 
-
 #define SERIAL_CMD_DDR_INIT    0x0C90
 #define SERIAL_CMD_REQ_VERSION 0x065A
 
@@ -441,19 +437,19 @@ void Serial_Req_Version_Clock_Handler(void)
       Serial_Init_Tick = HAL_GetTick();
       Serial_Bit = 0;
     case SERIAL_STATE_REQ_VERSION:
-      /* Send version parts (MAJOR, MINOR, PATCH) as 8-bits unsigned ints. */
+      /* Send version parts(MAJOR, MINOR, PATCH) as 8-bits unsigned ints, LSB first. */
       if(Serial_Bit < 24)
       {
         uint8_t versionPart = 0;
         switch(Serial_Bit / 8) {
           case 0:
-            versionPart = FW_VERSION_MAJOR;
+            versionPart = VERSION_MAJOR;
             break;
           case 1:
-            versionPart = FW_VERSION_MINOR;
+            versionPart = VERSION_MINOR;
             break;
           case 2:
-            versionPart = FW_VERSION_PATCH;
+            versionPart = VERSION_PATCH;
             break;
         }
 


### PR DESCRIPTION
Fixes #1 

Adds a new command that external devices can send to request the firmware version running on the board.

Serial data pin: FL5
Serial clock pin: TEST

**Command**
13-bits 0x065A LSB first sampled on clock rising edge. 
Do not send the remaining 3-bits.

**Reply**
3 bytes sent LSB first sampled on clock falling edge on PANEL_U_OUT or inverted on PANEL_R_OUT.
1st byte is version major.
2nd byte is version minor.
3rd byte is version patch.

